### PR TITLE
Add a prefix to title

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ You can list all the available options for EPUB Preview Factory using the comman
      -v, [--verbose=VERBOSE]                      # verbose mode
      -c, [--max-char=MAX_CHAR]                    # calcul the size of the extract by char count instead of percent
      -m, [--move-finish-files=MOVE_FINISH_FILES]  # move finished file to the following directory
+     -t, [--title-prefix=TITLE_PREFIX]            # add a prefix before preview’s title
 
 EPUB Preview Factory has two main modes: single file or batch.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can list all the available options for EPUB Preview Factory using the comman
      -v, [--verbose=VERBOSE]                      # verbose mode
      -c, [--max-char=MAX_CHAR]                    # calcul the size of the extract by char count instead of percent
      -m, [--move-finish-files=MOVE_FINISH_FILES]  # move finished file to the following directory
-     -t, [--title-prefix=TITLE_PREFIX]            # add a prefix before preview’s title
+     -t, [--title-prefix=TITLE_PREFIX]            # prefix title in preview
 
 EPUB Preview Factory has two main modes: single file or batch.
 

--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -13,6 +13,7 @@ class Extractor
     @added_content = []
     @final_para = nil
     @new_uuid = nil
+    @title_prefix = nil
     @debug = false
 
     total = get_total_count
@@ -142,6 +143,15 @@ class Extractor
       type_elem.value = "preview"
     end
 
+    unless @title_prefix.nil?
+      if @source_book.property_for("title").nil?
+        @source_book.add_property("title", @title_prefix)
+      else
+        title_elem = @source_book.properties.select{|p| p.key == "title"}.first
+        title_elem.value = @title_prefix + ' ' + title_elem.value
+      end
+    end
+
     unless @new_uuid.nil?
       if @source_book.property_for("bookid").nil?
         @source_book.add_property("bookid", @new_uuid)
@@ -178,6 +188,10 @@ class Extractor
 
   def set_book_identifier(identifier)
     @new_uuid = identifier
+  end
+
+  def set_title_prefix(prefix)
+    @title_prefix = prefix
   end
 
   def set_max_word(limit)

--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -148,7 +148,7 @@ class Extractor
         @source_book.add_property("title", @title_prefix)
       else
         title_elem = @source_book.properties.select{|p| p.key == "title"}.first
-        title_elem.value = @title_prefix + ' ' + title_elem.value
+        title_elem.value = "#{ @title_prefix } #{ title_elem.value }"
       end
     end
 

--- a/main.rb
+++ b/main.rb
@@ -16,7 +16,7 @@ class App < Thor
    method_option :verbose, :aliases => "-v", :desc => "verbose mode"
    method_option :max_char, :aliases => "-c", :desc => "calcul the size of the extract by char count instead of percent"
    method_option :move_finish_files, :aliases => "-m", :desc => "move finished file to the following directory"
-   method_option :title_prefix, :aliases => "-t", :desc => "add a prefix before preview’s title"
+   method_option :title_prefix, :aliases => "-t", :desc => "prefix title in preview"
 
   def extract
     directory_mode = File.directory?(options[:source])

--- a/main.rb
+++ b/main.rb
@@ -16,6 +16,8 @@ class App < Thor
    method_option :verbose, :aliases => "-v", :desc => "verbose mode"
    method_option :max_char, :aliases => "-c", :desc => "calcul the size of the extract by char count instead of percent"
    method_option :move_finish_files, :aliases => "-m", :desc => "move finished file to the following directory"
+   method_option :title_prefix, :aliases => "-t", :desc => "add a prefix before preview’s title"
+
   def extract
     directory_mode = File.directory?(options[:source])
     percent = options[:percent].to_i
@@ -91,6 +93,9 @@ class App < Thor
       end
       if options[:identifier]
         extract.set_book_identifier(options[:identifier])
+      end
+      if options[:title_prefix]
+        extract.set_title_prefix(options[:title_prefix])
       end
       extract.get_extract(options[:destination])
       FileUtils.rm_rf(options[:destination].gsub('.epub', ''))


### PR DESCRIPTION
Je modifie légèrement la classe du générateur et le binaire main.rb pour autoriser l'ajout d'un préfixe au titre afin d'identifier clairement qu'il s'agit d'un extrait. Ce titre modifié est bien visible par iBooks et par peregrin (la gem de manipulation et analyse d'ebooks fournie avec le présent générateur d'extrait).

Si le livre n'a pas de titre à la base, il se retrouve avec le préfixe tout seul. Voyez-vous une meilleure solution ?
