### PR TITLE
Modification du titre de l'extrait généré

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can list all the available options for EPUB Preview Factory using the comman
      -v, [--verbose=VERBOSE]                      # verbose mode
      -c, [--max-char=MAX_CHAR]                    # calcul the size of the extract by char count instead of percent
      -m, [--move-finish-files=MOVE_FINISH_FILES]  # move finished file to the following directory
-     -t, [--title-prefix=TITLE_PREFIX]            # prefix title in preview
+     -t, [--title=TITLE]                          # Change title in generated preview. Use ***title*** to include original title in preview title
 
 EPUB Preview Factory has two main modes: single file or batch.
 

--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -6,6 +6,8 @@ class Extractor
 
   SKIP_TAG = ["strong", "span", "body", "b", "em", "i"]
 
+  TITLE_TEMPLATE_FORMAT = '***title***'
+
   def initialize(filepath, pourcent_extract = 5)
     @source_file = Peregrin::Epub.read(filepath)
     @source_book = @source_file.to_book
@@ -143,12 +145,12 @@ class Extractor
       type_elem.value = "preview"
     end
 
-    unless @title_prefix.nil? and @title_suffix.nil?
+    unless @title_template.nil?
       if @source_book.property_for("title").nil?
-        @source_book.add_property("title", "#{ @title_prefix } #{ @title_suffix }".strip)
+        @source_book.add_property("title", @title_template.gsub(TITLE_TEMPLATE_FORMAT, ''))
       else
         title_elem = @source_book.properties.select{|p| p.key == "title"}.first
-        title_elem.value = "#{ @title_prefix } #{ title_elem.value } #{ @title_suffix }".strip
+        title_elem.value = @title_template.gsub(TITLE_TEMPLATE_FORMAT, title_elem.value)
       end
     end
 
@@ -190,12 +192,8 @@ class Extractor
     @new_uuid = identifier
   end
 
-  def set_title_prefix(prefix)
-    @title_prefix = prefix
-  end
-
-  def set_title_suffix(suffix)
-    @title_suffix = suffix
+  def set_title_template(template)
+    @title_template = template
   end
 
   def set_max_word(limit)

--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -143,12 +143,12 @@ class Extractor
       type_elem.value = "preview"
     end
 
-    unless @title_prefix.nil?
+    unless @title_prefix.nil? and @title_suffix.nil?
       if @source_book.property_for("title").nil?
-        @source_book.add_property("title", @title_prefix)
+        @source_book.add_property("title", "#{ @title_prefix } #{ @title_suffix }".strip)
       else
         title_elem = @source_book.properties.select{|p| p.key == "title"}.first
-        title_elem.value = "#{ @title_prefix } #{ title_elem.value }"
+        title_elem.value = "#{ @title_prefix } #{ title_elem.value } #{ @title_suffix }".strip
       end
     end
 
@@ -192,6 +192,10 @@ class Extractor
 
   def set_title_prefix(prefix)
     @title_prefix = prefix
+  end
+
+  def set_title_suffix(suffix)
+    @title_suffix = suffix
   end
 
   def set_max_word(limit)

--- a/main.rb
+++ b/main.rb
@@ -16,7 +16,8 @@ class App < Thor
    method_option :verbose, :aliases => "-v", :desc => "verbose mode"
    method_option :max_char, :aliases => "-c", :desc => "calcul the size of the extract by char count instead of percent"
    method_option :move_finish_files, :aliases => "-m", :desc => "move finished file to the following directory"
-   method_option :title_prefix, :aliases => "-t", :desc => "prefix title in preview"
+   method_option :title_prefix, :desc => "prefix title in preview"
+   method_option :title_suffix, :desc => "suffix title in preview"
 
   def extract
     directory_mode = File.directory?(options[:source])
@@ -96,6 +97,9 @@ class App < Thor
       end
       if options[:title_prefix]
         extract.set_title_prefix(options[:title_prefix])
+      end
+      if options[:title_suffix]
+        extract.set_title_suffix(options[:title_suffix])
       end
       extract.get_extract(options[:destination])
       FileUtils.rm_rf(options[:destination].gsub('.epub', ''))

--- a/main.rb
+++ b/main.rb
@@ -16,8 +16,7 @@ class App < Thor
    method_option :verbose, :aliases => "-v", :desc => "verbose mode"
    method_option :max_char, :aliases => "-c", :desc => "calcul the size of the extract by char count instead of percent"
    method_option :move_finish_files, :aliases => "-m", :desc => "move finished file to the following directory"
-   method_option :title_prefix, :desc => "prefix title in preview"
-   method_option :title_suffix, :desc => "suffix title in preview"
+   method_option :title, :aliases => "-t", :desc => "Change title in generated preview. Use #{ Extractor::TITLE_TEMPLATE_FORMAT } to include original title in preview title"
 
   def extract
     directory_mode = File.directory?(options[:source])
@@ -95,11 +94,8 @@ class App < Thor
       if options[:identifier]
         extract.set_book_identifier(options[:identifier])
       end
-      if options[:title_prefix]
-        extract.set_title_prefix(options[:title_prefix])
-      end
-      if options[:title_suffix]
-        extract.set_title_suffix(options[:title_suffix])
+      if options[:title]
+        extract.set_title_template(options[:title])
       end
       extract.get_extract(options[:destination])
       FileUtils.rm_rf(options[:destination].gsub('.epub', ''))


### PR DESCRIPTION
Mon premier dev ajoutait la possibilité de préfixer le titre de l'extrait généré, comme ceci : 

```
[Extrait] - La duchesse insoumise
```

ou

```
Extrait : la duchesse insoumise
```

Mais en fait, préfixer le titre tend à ranger tous les extraits dans la lettre `E` ou `[` dans les bibliothèques des liseuses qui proposent du tri alphabétique. Du coup, après croisement avec @damleg, on préfèrerait _suffixer_ le titre de l'extrait, comme ceci : 

```
La duchesse insoumise (Extrait)
```

ou

```
La duchesse insoumise - extrait
```

Donc voici le dev en question. On garde la possibilité de préfixer le titre quand même.

Pour lancer une extraction d'extrait avec suffixe, on lance cette commande : 

``` bash
bundle exec ruby main.rb extract -s epubs/la-duchesse-insoumise.epub -d epubs/extrait-la-duchesse-insoumise.epub --title-suffix="(Extrait)"
```

**_Edit :**_ finalement on est plus générique, on _modifie_ le titre en fournissant un template de la forme `***title*** - extrait`. 
